### PR TITLE
Fixed Cloudflare Crypto Issue

### DIFF
--- a/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_amd64.s
+++ b/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_amd64.s
@@ -110,7 +110,7 @@ TEXT ·gfpMul(SB),0,$160-24
 	MOVQ b+16(FP), SI
 
 	// Jump to a slightly different implementation if MULX isn't supported.
-	CMPB runtime·support_bmi2(SB), $0
+	CMPB ·hasBMI2(SB), $0
 	JE   nobmi2Mul
 
 	mulBMI2(0(DI),8(DI),16(DI),24(DI), 0(SI))

--- a/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_decl.go
+++ b/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_decl.go
@@ -5,6 +5,14 @@ package bn256
 // This file contains forward declarations for the architecture-specific
 // assembly implementations of these functions, provided that they exist.
 
+import (
+	"golang.org/x/sys/cpu"
+)
+
+//nolint:varcheck
+var hasBMI2 = cpu.X86.HasBMI2
+
+
 // go:noescape
 func gfpNeg(c, a *gfP)
 


### PR DESCRIPTION
When attempting to run `make`, I got the the following error:
`github.com/jpmorganchase/istanbul-tools/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare.gfpMul: relocation target runtime.support_bmi2 not defined`.

After doing research, it appears Go 1.11 dropped support for `support_bmi2`. Cloudflare updated their package to fix this, but this repository hasn't been updated yet to reflect this. The small changes in this PR replicate Cloudflare's fix to this repository.

*references*:
https://github.com/ethereum/go-ethereum/issues/17237
https://github.com/cloudflare/bn256/commit/f6d0dc96cf10d0c5ff00fc8733996a93fd04ce32