### PR TITLE
Deprecated commands have been updated with the new one.

### DIFF
--- a/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_amd64.s
+++ b/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_amd64.s
@@ -110,7 +110,7 @@ TEXT ·gfpMul(SB),0,$160-24
 	MOVQ b+16(FP), SI
 
 	// Jump to a slightly different implementation if MULX isn't supported.
-	CMPB runtime·support_bmi2(SB), $0
+	CMPB ·hasBMI2(SB), $0
 	JE   nobmi2Mul
 
 	mulBMI2(0(DI),8(DI),16(DI),24(DI), 0(SI))

--- a/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_decl.go
+++ b/vendor/github.com/ethereum/go-ethereum/crypto/bn256/cloudflare/gfp_decl.go
@@ -5,6 +5,12 @@ package bn256
 // This file contains forward declarations for the architecture-specific
 // assembly implementations of these functions, provided that they exist.
 
+import (
+	"golang.org/x/sys/cpu"
+)
+
+var hasBMI2 = cpu.X86.HasBMI2
+
 // go:noescape
 func gfpNeg(c, a *gfP)
 


### PR DESCRIPTION
Architecture-specific assembly implementations have changed in latest GoLang (since GoLang v1.11). Due to this incompatibility it is not possible to build Istanbul tools binary using *__make__* command with latest GoLang.
This pull request contains mandatory changes necessary to build istanbul-tools binary.

GoLang assembly changes reference: cloudflare/bn256@f6d0dc9

Changes verified by making build in the following environment:
Hardware - `MacBook Pro 15' (2015)`
OS - `MacOS Mojave 10.14.4`
Golang - `go version go1.12.1 darwin/amd64`
Cmake - `cmake version 3.13.4`