### PR TITLE
Restore the homestead flag in genesis

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -45,6 +45,7 @@ func New(options ...Option) *core.Genesis {
 		Alloc:      make(core.GenesisAlloc),
 		Config: &params.ChainConfig{
 			ChainId:        big.NewInt(10),
+			HomesteadBlock: big.NewInt(1),
 			ByzantiumBlock: big.NewInt(1),
 			EIP150Block:    big.NewInt(1),
 			EIP155Block:    big.NewInt(1),


### PR DESCRIPTION
Homestead flag was incorrectly removed previously when byzantium was enabled.

Impact of having it disabled is that a number of homestead features are not enabled; for example, if child contract creation runs out of gas then contract address is returned instead of error “contract creation code storage out of gas”.