### PR TITLE
Updated name of upload-artifacts step to correctly reference metadata…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ steps.env.outputs.os-arch }}
+          name: ${{ steps.meta.outputs.os-arch }}
           path: build/artifact
   deploy-cloudsmith:
     name: 'Deploy binary to Cloudsmith for ${{ matrix.goarch }}'


### PR DESCRIPTION
Fixing push to cloudsmith, by updating the name field of `upload-artifacts` step to correctly reference the `metadata` step