### PR TITLE
Rename package name github.com/jpmorganchase/istanbul-tools to github.com/Consensys/istanbul-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ qbft:
 
 load-testing:
 	@echo "Run load testing"
-	@CURDIR=$(CURDIR) go test -v github.com/jpmorganchase/istanbul-tools/tests/load/... --timeout 1h
+	@CURDIR=$(CURDIR) go test -v github.com/Consensys/istanbul-tools/tests/load/... --timeout 1h
 
 clean:
 	rm -rf build

--- a/charts/genesis.go
+++ b/charts/genesis.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 type GenesisChart struct {

--- a/charts/log.go
+++ b/charts/log.go
@@ -17,7 +17,7 @@
 package charts
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/charts/static_nodes.go
+++ b/charts/static_nodes.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jpmorganchase/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/common"
 )
 
 type StaticNodesChart struct {

--- a/client/log.go
+++ b/client/log.go
@@ -17,7 +17,7 @@
 package client
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/cmd/istanbul/address/cmd.go
+++ b/cmd/istanbul/address/cmd.go
@@ -5,9 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/p2p/enode"
-
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/istanbul/main.go
+++ b/cmd/istanbul/main.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/address"
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/extra"
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/reinit"
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/setup"
-	"github.com/jpmorganchase/istanbul-tools/cmd/utils"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/address"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/reinit"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/setup"
+	"github.com/Consensys/istanbul-tools/cmd/utils"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/istanbul/reinit/cmd.go
+++ b/cmd/istanbul/reinit/cmd.go
@@ -30,7 +30,7 @@ import (
   "github.com/ethereum/go-ethereum/core/types"
   "github.com/ethereum/go-ethereum/crypto"
   "github.com/ethereum/go-ethereum/rlp"
-  "github.com/jpmorganchase/istanbul-tools/genesis"
+  "github.com/Consensys/istanbul-tools/genesis"
   "github.com/urfave/cli"
 )
 

--- a/cmd/istanbul/reinit/cmd.go
+++ b/cmd/istanbul/reinit/cmd.go
@@ -17,120 +17,120 @@
 package reinit
 
 import (
-  "fmt"
-  "strings"
-  "sort"
-  "bytes"
-  "math/big"
-  "encoding/json"
-  "crypto/ecdsa"
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
 
-  "github.com/ethereum/go-ethereum/common"
-  "github.com/ethereum/go-ethereum/core"
-  "github.com/ethereum/go-ethereum/core/types"
-  "github.com/ethereum/go-ethereum/crypto"
-  "github.com/ethereum/go-ethereum/rlp"
-  "github.com/Consensys/istanbul-tools/genesis"
-  "github.com/urfave/cli"
+	"github.com/Consensys/istanbul-tools/genesis"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/urfave/cli"
 )
 
 var (
-  ReinitCommand = cli.Command{
-    Name:  "reinit",
-    Action: reinit,
-    Usage: "Reinitialize a genesis block using previous node info",
-    ArgsUsage: "\"nodekey1,nodekey2,...\"",
-    Flags: []cli.Flag{
-      nodeKeyFlag,
-      quorumFlag,
-    },
-    Description: `This tool helps generate a genesis block`,
-  }
+	ReinitCommand = cli.Command{
+		Name:      "reinit",
+		Action:    reinit,
+		Usage:     "Reinitialize a genesis block using previous node info",
+		ArgsUsage: "\"nodekey1,nodekey2,...\"",
+		Flags: []cli.Flag{
+			nodeKeyFlag,
+			quorumFlag,
+		},
+		Description: `This tool helps generate a genesis block`,
+	}
 )
 
 func reinit(ctx *cli.Context) error {
-  if !ctx.IsSet(nodeKeyFlag.Name) {
-    return cli.NewExitError("Must supply nodekeys", 10);
-  }
+	if !ctx.IsSet(nodeKeyFlag.Name) {
+		return cli.NewExitError("Must supply nodekeys", 10)
+	}
 
-  nodeKeyString := ctx.String(nodeKeyFlag.Name);
-  nodekeys := strings.Split(nodeKeyString, ",");
+	nodeKeyString := ctx.String(nodeKeyFlag.Name)
+	nodekeys := strings.Split(nodeKeyString, ",")
 
-  isQuorum := ctx.Bool(quorumFlag.Name);
+	isQuorum := ctx.Bool(quorumFlag.Name)
 
-  var stringAddrs []string;
-  _, _, addr := generateKeysWithNodeKey(nodekeys);
-  // Convert to String to sort
-  for i := 0; i < len(addr); i++ {
-    addrString, _ := json.Marshal(addr[i]);
-    stringAddrs = append(stringAddrs, string(addrString));
-  }
-  sort.Strings(stringAddrs);
+	var stringAddrs []string
+	_, _, addr := generateKeysWithNodeKey(nodekeys)
+	// Convert to String to sort
+	for i := 0; i < len(addr); i++ {
+		addrString, _ := json.Marshal(addr[i])
+		stringAddrs = append(stringAddrs, string(addrString))
+	}
+	sort.Strings(stringAddrs)
 
-  // Convert back to address
-  var addrs []common.Address;
-  for i := 0; i < len(stringAddrs); i++ {
-    var address common.Address;
-    json.Unmarshal([]byte(stringAddrs[i]), &address);
-    addrs = append(addrs, address);
-  }
-  // Generate Genesis block
-  genesisString, _ := getGenesisWithAddrs(addrs, isQuorum);
-  // genesisS, _ := json.Marshal(genesis);
-  fmt.Println(string(genesisString));
-  return nil;
+	// Convert back to address
+	var addrs []common.Address
+	for i := 0; i < len(stringAddrs); i++ {
+		var address common.Address
+		json.Unmarshal([]byte(stringAddrs[i]), &address)
+		addrs = append(addrs, address)
+	}
+	// Generate Genesis block
+	genesisString, _ := getGenesisWithAddrs(addrs, isQuorum)
+	// genesisS, _ := json.Marshal(genesis);
+	fmt.Println(string(genesisString))
+	return nil
 }
 
 func generateKeysWithNodeKey(nodekeysIn []string) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs []common.Address) {
-  for i := 0; i < len(nodekeysIn); i++ {
-    nodekey := nodekeysIn[i]
-    nodekeys = append(nodekeys, nodekey)
+	for i := 0; i < len(nodekeysIn); i++ {
+		nodekey := nodekeysIn[i]
+		nodekeys = append(nodekeys, nodekey)
 
-    key, err := crypto.HexToECDSA(nodekey)
-    if err != nil {
-      fmt.Println("Failed to generate key", "err", err)
-      return nil, nil, nil
-    }
-    keys = append(keys, key)
+		key, err := crypto.HexToECDSA(nodekey)
+		if err != nil {
+			fmt.Println("Failed to generate key", "err", err)
+			return nil, nil, nil
+		}
+		keys = append(keys, key)
 
-    addr := crypto.PubkeyToAddress(key.PublicKey)
-    addrs = append(addrs, addr)
-  }
-  return keys, nodekeys, addrs
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		addrs = append(addrs, addr)
+	}
+	return keys, nodekeys, addrs
 }
 
 func getGenesisWithAddrs(addrs []common.Address, isQuorum bool) ([]byte, error) {
-  // generate genesis block
-  istanbulGenesis := genesis.New(
-    genesis.Validators(addrs...),
-    genesis.Alloc(addrs, new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil)),
-  )
-  var jsonBytes []byte
-  var err error
-  if isQuorum {
-    jsonBytes, err = json.MarshalIndent(genesis.ToQuorum(istanbulGenesis, true), "", "    ")
-  } else {
-    jsonBytes, err = json.MarshalIndent(istanbulGenesis, "", "    ")
-  }
-  return jsonBytes, err
+	// generate genesis block
+	istanbulGenesis := genesis.New(
+		genesis.Validators(addrs...),
+		genesis.Alloc(addrs, new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil)),
+	)
+	var jsonBytes []byte
+	var err error
+	if isQuorum {
+		jsonBytes, err = json.MarshalIndent(genesis.ToQuorum(istanbulGenesis, true), "", "    ")
+	} else {
+		jsonBytes, err = json.MarshalIndent(istanbulGenesis, "", "    ")
+	}
+	return jsonBytes, err
 }
 
 func appendValidators(genesis *core.Genesis, addrs []common.Address) {
 
-  if len(genesis.ExtraData) < types.IstanbulExtraVanity {
-    genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, types.IstanbulExtraVanity)...)
-  }
-  genesis.ExtraData = genesis.ExtraData[:types.IstanbulExtraVanity]
+	if len(genesis.ExtraData) < types.IstanbulExtraVanity {
+		genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, types.IstanbulExtraVanity)...)
+	}
+	genesis.ExtraData = genesis.ExtraData[:types.IstanbulExtraVanity]
 
-  ist := &types.IstanbulExtra{
-    Validators:    addrs,
-    Seal:          []byte{},
-    CommittedSeal: [][]byte{},
-  }
+	ist := &types.IstanbulExtra{
+		Validators:    addrs,
+		Seal:          []byte{},
+		CommittedSeal: [][]byte{},
+	}
 
-  istPayload, err := rlp.EncodeToBytes(&ist)
-  if err != nil {
-    panic("failed to encode istanbul extra")
-  }
-  genesis.ExtraData = append(genesis.ExtraData, istPayload...)
+	istPayload, err := rlp.EncodeToBytes(&ist)
+	if err != nil {
+		panic("failed to encode istanbul extra")
+	}
+	genesis.ExtraData = append(genesis.ExtraData, istPayload...)
 }

--- a/cmd/istanbul/setup/cmd.go
+++ b/cmd/istanbul/setup/cmd.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/docker/compose"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/docker/compose"
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/qbft/main.go
+++ b/cmd/qbft/main.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/address"
-	"github.com/jpmorganchase/istanbul-tools/cmd/qbft/extra"
-	"github.com/jpmorganchase/istanbul-tools/cmd/qbft/reinit"
-	"github.com/jpmorganchase/istanbul-tools/cmd/qbft/setup"
-	"github.com/jpmorganchase/istanbul-tools/cmd/utils"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/address"
+	"github.com/Consensys/istanbul-tools/cmd/qbft/extra"
+	"github.com/Consensys/istanbul-tools/cmd/qbft/reinit"
+	"github.com/Consensys/istanbul-tools/cmd/qbft/setup"
+	"github.com/Consensys/istanbul-tools/cmd/utils"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/qbft/reinit/cmd.go
+++ b/cmd/qbft/reinit/cmd.go
@@ -24,9 +24,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/qbft/reinit/cmd.go
+++ b/cmd/qbft/reinit/cmd.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/qbft/setup/cmd.go
+++ b/cmd/qbft/setup/cmd.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/qbft/setup/cmd.go
+++ b/cmd/qbft/setup/cmd.go
@@ -27,10 +27,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/p2p/discv5"
 	istcommon "github.com/Consensys/istanbul-tools/common"
 	"github.com/Consensys/istanbul-tools/genesis"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/sendtx/main.go
+++ b/cmd/sendtx/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jpmorganchase/istanbul-tools/cmd/utils"
+	"github.com/Consensys/istanbul-tools/cmd/utils"
 	"github.com/urfave/cli"
 )
 

--- a/common/log.go
+++ b/common/log.go
@@ -17,7 +17,7 @@
 package common
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/common/transactions.go
+++ b/common/transactions.go
@@ -21,10 +21,9 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 
+	"github.com/Consensys/istanbul-tools/client"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/Consensys/istanbul-tools/client"
 )
 
 var (

--- a/common/transactions.go
+++ b/common/transactions.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/client"
 )
 
 var (

--- a/container/blockchain.go
+++ b/container/blockchain.go
@@ -33,9 +33,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/phayes/freeport"
 
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 const (

--- a/container/blockchain.go
+++ b/container/blockchain.go
@@ -27,15 +27,14 @@ import (
 	"path/filepath"
 	"time"
 
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/docker/docker/client"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/phayes/freeport"
-
-	istcommon "github.com/Consensys/istanbul-tools/common"
-	"github.com/Consensys/istanbul-tools/docker/service"
-	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 const (

--- a/container/constellation.go
+++ b/container/constellation.go
@@ -33,7 +33,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 
-	"github.com/jpmorganchase/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/common"
 )
 
 //TODO: refactor this with ethereum options?

--- a/container/constellation.go
+++ b/container/constellation.go
@@ -26,14 +26,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Consensys/istanbul-tools/common"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-
-	"github.com/Consensys/istanbul-tools/common"
 )
 
 //TODO: refactor this with ethereum options?

--- a/container/constellation_test.go
+++ b/container/constellation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/docker/service"
 	"github.com/phayes/freeport"
 )
 

--- a/container/constellation_test.go
+++ b/container/constellation_test.go
@@ -19,8 +19,8 @@ package container
 import (
 	"testing"
 
-	"github.com/docker/docker/client"
 	"github.com/Consensys/istanbul-tools/docker/service"
+	"github.com/docker/docker/client"
 	"github.com/phayes/freeport"
 )
 

--- a/container/ethereum.go
+++ b/container/ethereum.go
@@ -42,9 +42,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/client"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 const (

--- a/container/ethereum.go
+++ b/container/ethereum.go
@@ -30,6 +30,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Consensys/istanbul-tools/client"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -41,10 +44,6 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-
-	"github.com/Consensys/istanbul-tools/client"
-	istcommon "github.com/Consensys/istanbul-tools/common"
-	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 const (

--- a/container/log.go
+++ b/container/log.go
@@ -17,7 +17,7 @@
 package container
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/container/utils.go
+++ b/container/utils.go
@@ -17,13 +17,12 @@
 package container
 
 import (
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
-
-	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
 )
 
 func sigHash(header *types.Header) (hash common.Hash) {

--- a/container/utils.go
+++ b/container/utils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
 
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/extra"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
 )
 
 func sigHash(header *types.Header) (hash common.Hash) {

--- a/docker/compose/istanbul.go
+++ b/docker/compose/istanbul.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/docker/service"
 )
 
 type Compose interface {

--- a/docker/compose/quorum.go
+++ b/docker/compose/quorum.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/docker/service"
 )
 
 type quorum struct {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -23,12 +23,11 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Consensys/istanbul-tools/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-
-	"github.com/Consensys/istanbul-tools/common"
 )
 
 const (

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/jpmorganchase/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/common"
 )
 
 const (

--- a/genesis/log.go
+++ b/genesis/log.go
@@ -17,7 +17,7 @@
 package genesis
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/genesis/options.go
+++ b/genesis/options.go
@@ -19,11 +19,11 @@ package genesis
 import (
 	"math/big"
 
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
+	qbftExtra "github.com/Consensys/istanbul-tools/cmd/qbft/extra"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
-	qbftExtra "github.com/Consensys/istanbul-tools/cmd/qbft/extra"
 )
 
 type Option func(*core.Genesis)

--- a/genesis/options.go
+++ b/genesis/options.go
@@ -22,8 +22,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/jpmorganchase/istanbul-tools/cmd/istanbul/extra"
-	qbftExtra "github.com/jpmorganchase/istanbul-tools/cmd/qbft/extra"
+	"github.com/Consensys/istanbul-tools/cmd/istanbul/extra"
+	qbftExtra "github.com/Consensys/istanbul-tools/cmd/qbft/extra"
 )
 
 type Option func(*core.Genesis)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jpmorganchase/istanbul-tools
+module github.com/Consensys/istanbul-tools
 
 replace (
 	github.com/ethereum/go-ethereum => github.com/Consensys/quorum v1.2.2-0.20210819085930-d5ef77cafd90

--- a/k8s/blockchain.go
+++ b/k8s/blockchain.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/jpmorganchase/istanbul-tools/charts"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/charts"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/container"
 )
 
 func NewBlockchain(numOfValidators int, numOfExtraAccounts int, gaslimit uint64, isQourum bool, options ...Option) (bc *blockchain) {

--- a/k8s/blockchain.go
+++ b/k8s/blockchain.go
@@ -22,11 +22,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/Consensys/istanbul-tools/charts"
 	istcommon "github.com/Consensys/istanbul-tools/common"
 	"github.com/Consensys/istanbul-tools/container"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func NewBlockchain(numOfValidators int, numOfExtraAccounts int, gaslimit uint64, isQourum bool, options ...Option) (bc *blockchain) {

--- a/k8s/ethereum.go
+++ b/k8s/ethereum.go
@@ -32,10 +32,10 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/jpmorganchase/istanbul-tools/charts"
-	"github.com/jpmorganchase/istanbul-tools/client"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/charts"
+	"github.com/Consensys/istanbul-tools/client"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/container"
 )
 
 func NewEthereum(options ...Option) *ethereum {

--- a/k8s/ethereum.go
+++ b/k8s/ethereum.go
@@ -28,14 +28,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/Consensys/istanbul-tools/charts"
 	"github.com/Consensys/istanbul-tools/client"
 	istcommon "github.com/Consensys/istanbul-tools/common"
 	"github.com/Consensys/istanbul-tools/container"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func NewEthereum(options ...Option) *ethereum {

--- a/k8s/ethereum_example.go
+++ b/k8s/ethereum_example.go
@@ -17,9 +17,9 @@
 package k8s
 
 import (
-	"github.com/jpmorganchase/istanbul-tools/charts"
-	"github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/charts"
+	"github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/genesis"
 )
 
 func ExampleK8SEthereum() {

--- a/k8s/log.go
+++ b/k8s/log.go
@@ -17,7 +17,7 @@
 package k8s
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/k8s/rich_man.go
+++ b/k8s/rich_man.go
@@ -21,9 +21,8 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type RichMan interface {

--- a/k8s/rich_man.go
+++ b/k8s/rich_man.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
+	istcommon "github.com/Consensys/istanbul-tools/common"
 )
 
 type RichMan interface {

--- a/k8s/transactor.go
+++ b/k8s/transactor.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/client"
+	istcommon "github.com/Consensys/istanbul-tools/common"
 )
 
 type Transactor interface {

--- a/k8s/transactor.go
+++ b/k8s/transactor.go
@@ -23,10 +23,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/Consensys/istanbul-tools/client"
 	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type Transactor interface {

--- a/metrics/blockchain.go
+++ b/metrics/blockchain.go
@@ -27,8 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/container"
 )
 
 type SnapshotStopper func()

--- a/metrics/blockchain.go
+++ b/metrics/blockchain.go
@@ -23,12 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Consensys/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/Consensys/istanbul-tools/client"
-	"github.com/Consensys/istanbul-tools/container"
 )
 
 type SnapshotStopper func()

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -21,10 +21,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/Consensys/istanbul-tools/client"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/Consensys/istanbul-tools/client"
 )
 
 type metricClient struct {

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/client"
 )
 
 type metricClient struct {

--- a/metrics/ethereum.go
+++ b/metrics/ethereum.go
@@ -22,9 +22,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/jpmorganchase/istanbul-tools/client"
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/k8s"
+	"github.com/Consensys/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/k8s"
 )
 
 type metricEthereum struct {

--- a/metrics/log.go
+++ b/metrics/log.go
@@ -17,7 +17,7 @@
 package metrics
 
 import (
-	logging "github.com/jpmorganchase/istanbul-tools/log"
+	logging "github.com/Consensys/istanbul-tools/log"
 )
 
 var log = logging.New()

--- a/tests/functional/block_sync_test.go
+++ b/tests/functional/block_sync_test.go
@@ -24,8 +24,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("Block synchronization testing", func() {

--- a/tests/functional/byzantine_faulty_test.go
+++ b/tests/functional/byzantine_faulty_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-05: Byzantine Faulty", func() {

--- a/tests/functional/dynamic_test.go
+++ b/tests/functional/dynamic_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-02: Dynamic validators addition/removal testing", func() {

--- a/tests/functional/general_consensus_test.go
+++ b/tests/functional/general_consensus_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-01: General consensus", func() {

--- a/tests/functional/general_consensus_test.go
+++ b/tests/functional/general_consensus_test.go
@@ -26,11 +26,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/Consensys/istanbul-tools/container"
 	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/Consensys/istanbul-tools/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var _ = Describe("TFS-01: General consensus", func() {

--- a/tests/functional/gossip_network_test.go
+++ b/tests/functional/gossip_network_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-07: Gossip Network", func() {

--- a/tests/functional/integration_test.go
+++ b/tests/functional/integration_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/container"
 )
 
 // Example

--- a/tests/functional/non_byzantine_faulty_test.go
+++ b/tests/functional/non_byzantine_faulty_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-04: Non-Byzantine Faulty", func() {

--- a/tests/functional/recoverability_test.go
+++ b/tests/functional/recoverability_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TFS-03: Recoverability testing", func() {

--- a/tests/load/load_test.go
+++ b/tests/load/load_test.go
@@ -27,11 +27,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	istcommon "github.com/jpmorganchase/istanbul-tools/common"
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/k8s"
-	"github.com/jpmorganchase/istanbul-tools/metrics"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	istcommon "github.com/Consensys/istanbul-tools/common"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/k8s"
+	"github.com/Consensys/istanbul-tools/metrics"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("TPS-01: Large amount of transactions", func() {

--- a/tests/quorum/functional/block_sync_test.go
+++ b/tests/quorum/functional/block_sync_test.go
@@ -24,9 +24,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("Block synchronization testing", func() {

--- a/tests/quorum/functional/byzantine_faulty_test.go
+++ b/tests/quorum/functional/byzantine_faulty_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-05: Byzantine Faulty", func() {

--- a/tests/quorum/functional/dynamic_test.go
+++ b/tests/quorum/functional/dynamic_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-02: Dynamic validators addition/removal testing", func() {

--- a/tests/quorum/functional/general_consensus_test.go
+++ b/tests/quorum/functional/general_consensus_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/genesis"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/genesis"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-01: General consensus", func() {

--- a/tests/quorum/functional/general_consensus_test.go
+++ b/tests/quorum/functional/general_consensus_test.go
@@ -26,11 +26,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/Consensys/istanbul-tools/container"
 	"github.com/Consensys/istanbul-tools/genesis"
 	"github.com/Consensys/istanbul-tools/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var _ = Describe("QFS-01: General consensus", func() {

--- a/tests/quorum/functional/gossip_network_test.go
+++ b/tests/quorum/functional/gossip_network_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-07: Gossip Network", func() {

--- a/tests/quorum/functional/integration_test.go
+++ b/tests/quorum/functional/integration_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/docker/service"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/docker/service"
 )
 
 var dockerNetwork *container.DockerNetwork

--- a/tests/quorum/functional/non_byzantine_faulty_test.go
+++ b/tests/quorum/functional/non_byzantine_faulty_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-04: Non-Byzantine Faulty", func() {

--- a/tests/quorum/functional/private_transaction_test.go
+++ b/tests/quorum/functional/private_transaction_test.go
@@ -26,10 +26,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/Consensys/istanbul-tools/client"
 	"github.com/Consensys/istanbul-tools/container"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 const (

--- a/tests/quorum/functional/private_transaction_test.go
+++ b/tests/quorum/functional/private_transaction_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/jpmorganchase/istanbul-tools/client"
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/client"
+	"github.com/Consensys/istanbul-tools/container"
 )
 
 const (

--- a/tests/quorum/functional/recoverability_test.go
+++ b/tests/quorum/functional/recoverability_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
-	"github.com/jpmorganchase/istanbul-tools/tests"
+	"github.com/Consensys/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/tests"
 )
 
 var _ = Describe("QFS-03: Recoverability testing", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -19,7 +19,7 @@ package tests
 import (
 	"sync"
 
-	"github.com/jpmorganchase/istanbul-tools/container"
+	"github.com/Consensys/istanbul-tools/container"
 	"github.com/onsi/ginkgo"
 )
 


### PR DESCRIPTION
`istanbul-tools` repository was still referencing `github.com/jpmorganchase/istanbul-tools` package names after the repository was transferred to `Consensys` org. This PR updates the package name to use `github.com/Consensys/istanbul-tools` instead. Also the module name has been updated to `github.com/Consensys/istanbul-tools`